### PR TITLE
chore: bump version to 6.99.0090

### DIFF
--- a/Carthage/purchase-connector-dynamic.json
+++ b/Carthage/purchase-connector-dynamic.json
@@ -11,5 +11,6 @@
   "6.16.2": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.16.2/purchase-connector-dynamic.xcframework.zip",
   "6.17.0": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.17.0/purchase-connector-dynamic.xcframework.zip",
   "6.17.1": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.17.1/purchase-connector-dynamic.xcframework.zip",
-  "6.99.008": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.008/purchase-connector-dynamic.xcframework.zip"
+  "6.99.008": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.008/purchase-connector-dynamic.xcframework.zip",
+  "6.99.0090": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.0090/purchase-connector-dynamic.xcframework.zip"
 }

--- a/Carthage/purchase-connector-static.json
+++ b/Carthage/purchase-connector-static.json
@@ -11,5 +11,6 @@
   "6.16.2": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.16.2/purchase-connector-static.xcframework.zip",
   "6.17.0": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.17.0/purchase-connector-static.xcframework.zip",
   "6.17.1": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.17.1/purchase-connector-static.xcframework.zip",
-  "6.99.008": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.008/purchase-connector-static.xcframework.zip"
+  "6.99.008": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.008/purchase-connector-static.xcframework.zip",
+  "6.99.0090": "https://github.com/AppsFlyerSDK/appsflyer-apple-purchase-connector/releases/download/6.99.0090/purchase-connector-static.xcframework.zip"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             targets: ["PurchaseConnector"])
     ],
     dependencies: [
-        .package(url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static.git", exact: "6.99.008")
+        .package(url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static.git", exact: "6.99.0090")
     ],
     targets: [
         .binaryTarget(

--- a/PurchaseConnector.podspec
+++ b/PurchaseConnector.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name             = 'PurchaseConnector'
-    s.version          = "6.99.008"
+    s.version          = "6.99.0090"
     s.summary          = 'AppsFlyer iOS SDK ARS'
 
     s.description      = <<-DESC
@@ -22,20 +22,20 @@ Pod::Spec.new do |s|
     s.swift_version = '5.0'
 
     s.subspec 'Main' do |ss|
-        ss.ios.dependency 'AppsFlyerFramework', '6.99.008'
+        ss.ios.dependency 'AppsFlyerFramework', '6.99.0090'
         ss.ios.preserve_paths = 'PurchaseConnector.xcframework'
         ss.ios.vendored_frameworks = 'PurchaseConnector.xcframework'
         ss.ios.resource_bundles = {'PurchaseConnector_Privacy' => ['Resources/PrivacyInfo.xcprivacy']}
      end
 
     s.subspec 'Dynamic' do |ss|
-        ss.ios.dependency 'AppsFlyerFramework/Dynamic','6.99.008'
+        ss.ios.dependency 'AppsFlyerFramework/Dynamic','6.99.0090'
         ss.ios.preserve_paths = 'Dynamic/PurchaseConnector.xcframework'
         ss.ios.vendored_frameworks = 'Dynamic/PurchaseConnector.xcframework'
    end
 
     s.subspec 'Strict' do |ss|
-        ss.ios.dependency 'AppsFlyerFramework/Strict','6.99.008'
+        ss.ios.dependency 'AppsFlyerFramework/Strict','6.99.0090'
         ss.ios.preserve_paths = 'PurchaseConnector.xcframework'
         ss.ios.vendored_frameworks = 'PurchaseConnector.xcframework'
         ss.ios.resource_bundles = {'PurchaseConnector_Privacy' => ['Resources/PrivacyInfo.xcprivacy']}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bla bla test
 
 ## <a id="plugin-build-for"> This Module is Built for
 - AppsFlyer SDK:
-- iOS AppsFlyer SDK **6.99.008** .
+- iOS AppsFlyer SDK **6.99.0090** .
 - 6.8.0+: StoreKit 1 support
 - 6.16.2+: StoreKit 1 & 2 support
 - Minimum iOS Version: 12
@@ -52,6 +52,7 @@ bla bla test
 | 6.17.0   |  6.17.0 |
 | 6.17.1   |  6.17.1 |
 | 6.99.008   |  6.99.008 |
+| 6.99.0090   |  6.99.0090 |
 
 ## <a id="cocoapods">  Adding The Connector To Your Project via Cocoapods: 
 Add to your Podfile and run `pod install`:


### PR DESCRIPTION
**Automated Version Bump**

Updates all version references for release 6.99.0090.

**Files Updated:**
- Carthage/*.json - Updated download URLs and checksums  
- PurchaseConnector.podspec - Bumped version number
- Package.swift - Updated SPM version and dependencies
- README.md - Updated documentation with new version